### PR TITLE
PATCH agregar header custome

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -17,7 +17,7 @@ builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("flowCraft"));
 });
 
-// Obtener la secret key desde la configuración
+// Obtener la secret key desde la configuraciï¿½n
 var secretKey = builder.Configuration["ApiSettings:secretToken"];
 
 // agregar servicio e interfaz
@@ -56,7 +56,7 @@ builder.Services.AddSwaggerGen();
 //Se usa (*) para todos los dominios
 builder.Services.AddCors(p => p.AddPolicy("PoliticaCors", build =>
 {
-    build.WithOrigins("*").AllowAnyMethod().AllowAnyHeader();
+    build.WithOrigins("*").AllowAnyMethod().AllowAnyHeader().WithExposedHeaders("JWT");
 }));
 
 var app = builder.Build();


### PR DESCRIPTION
## Resumen 
Como parte del manejo de la autorizacion en la web de flowcraft y como estamos trabajando con politica cors. Para poder acceder desde el cliente al header JWT el backend lo debe exponer de manera explicita. 

Por eso actualice la forma en la cual se habilita cors para poder tener acceso a ese campo